### PR TITLE
Assure Dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,9 @@ requirements:
 
 
 test:
+  commands:
+    # make sure all required dependencies are present
+    - python -c "import pkg_resources; pkg_resources.require('Orange3-Text')"
   imports:
     - orangecontrib.text
 


### PR DESCRIPTION
This PR should assure that new builds with missing dependencies fail before their PR could be accepted and published on conda-forge. Hence no widgets shouldn't be missing due to a forgotten dependency.