### PR TITLE
Import Documents dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,11 @@ requirements:
     - wikipedia
     - pyqt            4.11.*
     - typing
+    - pdfminer3k      >=1.3.1
+    - odfpy           >=1.3.5
+    - docx2txt        >=0.6
+    - lxml
+
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k]
   script: python setup.py install --single-version-externally-managed --record record.txt
 


### PR DESCRIPTION
Required dependencies:

- [x] pdfminer3k      >=1.3.1; [added to conda-forge](https://github.com/conda-forge/pdfminer3k-feedstock)
- [x] odfpy           >=1.3.5
- [x] docx2txt        >=0.6; [added missing py36 build](https://github.com/conda-forge/docx2txt-feedstock/pull/2)
- [x] lxml